### PR TITLE
Fix hard-coded database port

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ type DBConfig struct {
 }
 
 func (cfg *DBConfig) connectionString() string {
-	connStr := fmt.Sprintf("%s:%s@tcp(%s:3306)/%s", cfg.User, cfg.Pass, cfg.IP, cfg.DB)
+	connStr := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", cfg.User, cfg.Pass, cfg.IP, cfg.Port, cfg.DB)
 	log.Println(connStr)
 	return connStr
 }


### PR DESCRIPTION
Replaces the hard-coded port in the connection string with the port loaded from the user configuration file.